### PR TITLE
admission queue for build and deploy job

### DIFF
--- a/charts/lucity/templates/conductor-rbac.yaml
+++ b/charts/lucity/templates/conductor-rbac.yaml
@@ -90,7 +90,7 @@ metadata:
 rules:
   - apiGroups: ["batch"]
     resources: [jobs]
-    verbs: [get, list, watch, create]
+    verbs: [get, list, watch, create, patch]
   - apiGroups: [""]
     resources: [pods, pods/log]
     verbs: [get, list]
@@ -124,7 +124,7 @@ metadata:
 rules:
   - apiGroups: ["batch"]
     resources: [jobs]
-    verbs: [get, list, watch, create]
+    verbs: [get, list, watch, create, patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/services/conductor/cmd/conductor/main.go
+++ b/services/conductor/cmd/conductor/main.go
@@ -10,8 +10,8 @@ import (
 	webhookhttp "github.com/zeitlos/lucity/services/conductor/internal/api/webhook/http"
 	buildjobK8s "github.com/zeitlos/lucity/services/conductor/internal/buildjob/kubernetes"
 	"github.com/zeitlos/lucity/services/conductor/internal/conductor"
-	deployjobK8s "github.com/zeitlos/lucity/services/conductor/internal/deployjob/kubernetes"
 	helmDeployer "github.com/zeitlos/lucity/services/conductor/internal/deployer/helm"
+	deployjobK8s "github.com/zeitlos/lucity/services/conductor/internal/deployjob/kubernetes"
 	directoryLogto "github.com/zeitlos/lucity/services/conductor/internal/directory/logto"
 	environmentK8s "github.com/zeitlos/lucity/services/conductor/internal/environment/kubernetes"
 	"github.com/zeitlos/lucity/services/conductor/internal/gateway"
@@ -19,6 +19,7 @@ import (
 	"github.com/zeitlos/lucity/services/conductor/internal/metrics"
 	"github.com/zeitlos/lucity/services/conductor/internal/objectstorage"
 	objectstorageOVH "github.com/zeitlos/lucity/services/conductor/internal/objectstorage/ovh"
+	"github.com/zeitlos/lucity/services/conductor/internal/pipeline"
 	"github.com/zeitlos/lucity/services/conductor/internal/planner/railpack"
 	platformK8s "github.com/zeitlos/lucity/services/conductor/internal/platform/kubernetes"
 	"github.com/zeitlos/lucity/services/conductor/internal/resources"
@@ -96,6 +97,9 @@ type Config struct {
 	// Deploy jobs
 	DeployImage          string `envconfig:"DEPLOY_IMAGE" required:"true"`
 	DeployServiceAccount string `envconfig:"DEPLOY_SERVICE_ACCOUNT"`
+
+	MaxConcurrentReleases int `envconfig:"MAX_CONCURRENT_RELEASES" default:"5"`
+	MaxQueuedReleases     int `envconfig:"MAX_QUEUED_RELEASES" default:"10"`
 
 	SystemNamespace string `envconfig:"SYSTEM_NAMESPACE" default:"lucity-system"`
 
@@ -244,6 +248,8 @@ func main() {
 		GatewayNS:       config.GatewayNamespace,
 	})
 
+	pipelineClient := pipeline.New(k8sClient, config.BuildNamespace, config.SystemNamespace, config.MaxConcurrentReleases)
+
 	secret, err := k8sClient.CoreV1().Secrets(config.SystemNamespace).Get(ctx, config.RegistryPullSecret, metav1.GetOptions{})
 
 	if err != nil {
@@ -333,8 +339,12 @@ func main() {
 		LoadBalancerIP:       config.IPAddress,
 		GitHubAppSlug:        config.GitHubAppSlug,
 		DashboardURL:         config.DashboardURL,
+		MaxQueuedReleases:    config.MaxQueuedReleases,
 	}
-	conductor := conductor.New(cashierClient, githubApp, logtoClient, tokenRefresher, directoryClient, platformClient, jobsClient, deployJobsClient, planner, source, hostnameClient, gatewayClient, deployerClient, environmentClient, objectStorageClient, metricsProvider, conductorConfig)
+	conductor := conductor.New(cashierClient, githubApp, logtoClient, tokenRefresher, directoryClient, platformClient, jobsClient, deployJobsClient, pipelineClient, planner, source, hostnameClient, gatewayClient, deployerClient, environmentClient, objectStorageClient, metricsProvider, conductorConfig)
+
+	go runAdmissionReconciler(ctx, pipelineClient)
+	slog.Info("release admission ready", "maxConcurrent", config.MaxConcurrentReleases, "maxQueuedPerWorkspace", config.MaxQueuedReleases)
 
 	if config.ReconcileEnabled {
 		go runDomainReconciler(ctx, conductor)

--- a/services/conductor/cmd/conductor/reconcile.go
+++ b/services/conductor/cmd/conductor/reconcile.go
@@ -6,10 +6,20 @@ import (
 	"time"
 
 	"github.com/zeitlos/lucity/services/conductor/internal/conductor"
+	"github.com/zeitlos/lucity/services/conductor/internal/pipeline"
 )
 
 const domainReconcileInterval = 2 * time.Minute
 const serviceReconcileInterval = 2 * time.Minute
+const admissionInterval = 3 * time.Second
+
+func runAdmissionReconciler(ctx context.Context, p pipeline.Interface) {
+	reconcile(ctx, admissionInterval, func() {
+		if err := p.Reconcile(ctx); err != nil {
+			slog.Error("release admission failed", "error", err)
+		}
+	})
+}
 
 func runDomainReconciler(ctx context.Context, c *conductor.Client) {
 	reconcile(ctx, domainReconcileInterval, func() {

--- a/services/conductor/internal/buildjob/interface.go
+++ b/services/conductor/internal/buildjob/interface.go
@@ -42,6 +42,7 @@ type Job struct {
 	ContextPath   string
 	TriggeredBy   string
 	ReleaseID     string
+	CreatedAt     time.Time
 	StartedAt     *time.Time
 	FinishedAt    *time.Time
 	ImageRefs     map[string]name.Reference

--- a/services/conductor/internal/buildjob/kubernetes/kubernetes.go
+++ b/services/conductor/internal/buildjob/kubernetes/kubernetes.go
@@ -72,6 +72,7 @@ func toJob(job batch.Job) buildjob.Job {
 		ContextPath:   job.Annotations[annotationContext],
 		TriggeredBy:   job.Annotations[annotationTriggeredBy],
 		ReleaseID:     job.Labels[labelRelease],
+		CreatedAt:     job.CreationTimestamp.Time,
 		ImageRefs:     make(map[string]name.Reference),
 	}
 

--- a/services/conductor/internal/buildjob/kubernetes/lifecycle.go
+++ b/services/conductor/internal/buildjob/kubernetes/lifecycle.go
@@ -217,6 +217,7 @@ func (c *Client) newBuildJob(id string, opts buildjob.StartOptions, repoURL url.
 			Annotations: annotations,
 		},
 		Spec: batch.JobSpec{
+			Suspend:                 ptr.To(true),
 			BackoffLimit:            ptr.To(int32(0)),
 			TTLSecondsAfterFinished: ptr.To(int32(7 * 24 * 3600)),
 			ActiveDeadlineSeconds:   ptr.To(int64(30 * 60)),

--- a/services/conductor/internal/conductor/build.go
+++ b/services/conductor/internal/conductor/build.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/zeitlos/lucity/pkg/auth"
@@ -106,6 +107,16 @@ func (c *Client) Deploy(ctx context.Context, serviceID ServiceID, gitRef string)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if c.config.MaxQueuedReleases > 0 {
+		queued, err := c.pipeline.QueuedRuns(ctx, service.ID.Workspace)
+
+		if err != nil {
+			slog.WarnContext(ctx, "queued release count failed", "error", err, "workspace", service.ID.Workspace)
+		} else if queued >= c.config.MaxQueuedReleases {
+			return nil, fmt.Errorf("deployment queue is full (%d queued) — wait for queued releases to finish", queued)
+		}
 	}
 
 	claims, _ := auth.FromContext(ctx)

--- a/services/conductor/internal/conductor/conductor.go
+++ b/services/conductor/internal/conductor/conductor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/zeitlos/lucity/services/conductor/internal/hostname"
 	"github.com/zeitlos/lucity/services/conductor/internal/metrics"
 	"github.com/zeitlos/lucity/services/conductor/internal/objectstorage"
+	"github.com/zeitlos/lucity/services/conductor/internal/pipeline"
 	"github.com/zeitlos/lucity/services/conductor/internal/planner"
 	"github.com/zeitlos/lucity/services/conductor/internal/platform"
 	"github.com/zeitlos/lucity/services/conductor/internal/registry"
@@ -41,6 +42,7 @@ type Client struct {
 	platform    platform.Interface
 	buildjob    buildjob.Interface
 	deployjob   deployjob.Interface
+	pipeline    pipeline.Interface
 	planner     planner.Interface
 	source      source.Interface
 	hostname      *hostname.Client
@@ -75,9 +77,10 @@ type Config struct {
 	LoadBalancerIP       string
 	GitHubAppSlug        string
 	DashboardURL         string
+	MaxQueuedReleases    int
 }
 
-func New(cashier cashier.CashierServiceClient, githubApp *ghpkg.App, logto *logto.Client, tokenRefresher TokenRefresher, directory directory.Interface, platform platform.Interface, buildjob buildjob.Interface, deployjob deployjob.Interface, planner planner.Interface, source source.Interface, hostname *hostname.Client, gateway *gateway.Client, deployer deployer.Interface, environment environment.Interface, objectStorage objectstorage.Interface, metrics *metrics.Provider, config Config) *Client {
+func New(cashier cashier.CashierServiceClient, githubApp *ghpkg.App, logto *logto.Client, tokenRefresher TokenRefresher, directory directory.Interface, platform platform.Interface, buildjob buildjob.Interface, deployjob deployjob.Interface, pipeline pipeline.Interface, planner planner.Interface, source source.Interface, hostname *hostname.Client, gateway *gateway.Client, deployer deployer.Interface, environment environment.Interface, objectStorage objectstorage.Interface, metrics *metrics.Provider, config Config) *Client {
 	return &Client{
 		cashier:        cashier,
 		gitHubApp:      githubApp,
@@ -89,6 +92,7 @@ func New(cashier cashier.CashierServiceClient, githubApp *ghpkg.App, logto *logt
 		platform:       platform,
 		buildjob:       buildjob,
 		deployjob:      deployjob,
+		pipeline:       pipeline,
 		planner:        planner,
 		source:         source,
 		hostname:       hostname,

--- a/services/conductor/internal/conductor/release.go
+++ b/services/conductor/internal/conductor/release.go
@@ -248,8 +248,14 @@ func releaseTrigger(deployment *Deployment) ReleaseTrigger {
 }
 
 func releaseCreatedAt(build *Build, deploy *Deploy, deployment *Deployment) time.Time {
-	if build != nil && build.StartedAt != nil {
-		return *build.StartedAt
+	if build != nil {
+		if build.StartedAt != nil {
+			return *build.StartedAt
+		}
+
+		if !build.CreatedAt.IsZero() {
+			return build.CreatedAt
+		}
 	}
 
 	if deployment != nil {

--- a/services/conductor/internal/deployjob/kubernetes/lifecycle.go
+++ b/services/conductor/internal/deployjob/kubernetes/lifecycle.go
@@ -65,6 +65,7 @@ func (c *Client) newDeployJob(name string, opts deployjob.StartOptions) *batch.J
 			},
 		},
 		Spec: batch.JobSpec{
+			Suspend:                 ptr.To(true),
 			BackoffLimit:            ptr.To(int32(2)),
 			TTLSecondsAfterFinished: ptr.To(int32(7 * 24 * 3600)),
 			ActiveDeadlineSeconds:   ptr.To(int64(40 * 60)),

--- a/services/conductor/internal/pipeline/pipeline.go
+++ b/services/conductor/internal/pipeline/pipeline.go
@@ -1,0 +1,270 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	batch "k8s.io/api/batch/v1"
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/zeitlos/lucity/pkg/labels"
+)
+
+type Interface interface {
+	Reconcile(ctx context.Context) error
+	QueuedRuns(ctx context.Context, workspace string) (int, error)
+}
+
+const labelComponent = labels.Prefix + "component"
+
+type Client struct {
+	kubernetes      kubernetes.Interface
+	buildNamespace  string
+	deployNamespace string
+	maxConcurrent   int
+}
+
+func New(kubernetes kubernetes.Interface, buildNamespace, deployNamespace string, maxConcurrent int) *Client {
+	return &Client{
+		kubernetes:      kubernetes,
+		buildNamespace:  buildNamespace,
+		deployNamespace: deployNamespace,
+		maxConcurrent:   maxConcurrent,
+	}
+}
+
+var _ Interface = (*Client)(nil)
+
+type runState int
+
+const (
+	runTerminal runState = iota
+	runQueued
+	runActive
+)
+
+type job struct {
+	namespace string
+	name      string
+	suspended bool
+	terminal  bool
+}
+
+type run struct {
+	workspace string
+	key       string
+	createdAt time.Time
+	jobs      []job
+}
+
+func (r run) state() runState {
+	queued := false
+
+	for _, j := range r.jobs {
+		if j.terminal {
+			continue
+		}
+
+		if !j.suspended {
+			return runActive
+		}
+
+		queued = true
+	}
+
+	if queued {
+		return runQueued
+	}
+
+	return runTerminal
+}
+
+// Reconcile admits queued release runs: at most one active run per workspace,
+// oldest first, bounded by the global concurrency cap.
+func (c *Client) Reconcile(ctx context.Context) error {
+	runs, err := c.runs(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	active := 0
+	activeWorkspaces := map[string]bool{}
+	queuedByWorkspace := map[string][]run{}
+
+	for _, r := range runs {
+		switch r.state() {
+		case runActive:
+			active++
+			activeWorkspaces[r.workspace] = true
+
+			if err := c.resume(ctx, r); err != nil {
+				return fmt.Errorf("resume partially admitted run %q: %w", r.key, err)
+			}
+		case runQueued:
+			queuedByWorkspace[r.workspace] = append(queuedByWorkspace[r.workspace], r)
+		}
+	}
+
+	var candidates []run
+
+	for workspace, queue := range queuedByWorkspace {
+		if !activeWorkspaces[workspace] {
+			candidates = append(candidates, queue[0])
+		}
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if !candidates[i].createdAt.Equal(candidates[j].createdAt) {
+			return candidates[i].createdAt.Before(candidates[j].createdAt)
+		}
+
+		return candidates[i].key < candidates[j].key
+	})
+
+	for _, candidate := range candidates {
+		if c.maxConcurrent > 0 && active >= c.maxConcurrent {
+			break
+		}
+
+		if err := c.resume(ctx, candidate); err != nil {
+			return fmt.Errorf("admit run %q: %w", candidate.key, err)
+		}
+
+		active++
+	}
+
+	return nil
+}
+
+func (c *Client) QueuedRuns(ctx context.Context, workspace string) (int, error) {
+	runs, err := c.runs(ctx)
+
+	if err != nil {
+		return 0, err
+	}
+
+	count := 0
+
+	for _, r := range runs {
+		if r.workspace == workspace && r.state() == runQueued {
+			count++
+		}
+	}
+
+	return count, nil
+}
+
+var unsuspendPatch = []byte(`{"spec":{"suspend":false}}`)
+
+func (c *Client) resume(ctx context.Context, r run) error {
+	for _, j := range r.jobs {
+		if !j.suspended || j.terminal {
+			continue
+		}
+
+		_, err := c.kubernetes.BatchV1().Jobs(j.namespace).Patch(ctx, j.name, types.StrategicMergePatchType, unsuspendPatch, meta.PatchOptions{})
+
+		if err != nil {
+			return fmt.Errorf("unsuspend job %s/%s: %w", j.namespace, j.name, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) runs(ctx context.Context) ([]run, error) {
+	builds, err := c.kubernetes.BatchV1().Jobs(c.buildNamespace).List(ctx, meta.ListOptions{
+		LabelSelector: labelComponent + "=build",
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	deploys, err := c.kubernetes.BatchV1().Jobs(c.deployNamespace).List(ctx, meta.ListOptions{
+		LabelSelector: labelComponent + "=deploy",
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	groups := map[string]*run{}
+
+	add := func(k8sJob batch.Job) {
+		workspace := k8sJob.Labels[labels.Workspace]
+
+		if workspace == "" {
+			return
+		}
+
+		key := k8sJob.Labels[labels.Release]
+
+		if key == "" {
+			key = k8sJob.Name
+		}
+
+		groupKey := workspace + "/" + key
+		group, ok := groups[groupKey]
+
+		if !ok {
+			group = &run{workspace: workspace, key: groupKey, createdAt: k8sJob.CreationTimestamp.Time}
+			groups[groupKey] = group
+		}
+
+		if k8sJob.CreationTimestamp.Time.Before(group.createdAt) {
+			group.createdAt = k8sJob.CreationTimestamp.Time
+		}
+
+		group.jobs = append(group.jobs, job{
+			namespace: k8sJob.Namespace,
+			name:      k8sJob.Name,
+			suspended: k8sJob.Spec.Suspend != nil && *k8sJob.Spec.Suspend,
+			terminal:  jobTerminal(k8sJob),
+		})
+	}
+
+	for _, item := range builds.Items {
+		add(item)
+	}
+
+	for _, item := range deploys.Items {
+		add(item)
+	}
+
+	runs := make([]run, 0, len(groups))
+
+	for _, group := range groups {
+		runs = append(runs, *group)
+	}
+
+	sort.Slice(runs, func(i, j int) bool {
+		if !runs[i].createdAt.Equal(runs[j].createdAt) {
+			return runs[i].createdAt.Before(runs[j].createdAt)
+		}
+
+		return runs[i].key < runs[j].key
+	})
+
+	return runs, nil
+}
+
+func jobTerminal(k8sJob batch.Job) bool {
+	for _, condition := range k8sJob.Status.Conditions {
+		if condition.Status != core.ConditionTrue {
+			continue
+		}
+
+		if condition.Type == batch.JobComplete || condition.Type == batch.JobFailed {
+			return true
+		}
+	}
+
+	return false
+}

--- a/services/dashboard/src/composables/useCanvasReleaseStatus.ts
+++ b/services/dashboard/src/composables/useCanvasReleaseStatus.ts
@@ -26,8 +26,6 @@ const IN_FLIGHT_STATUSES = new Set<ReleaseStatus>([
   ReleaseStatus.Deploying,
 ]);
 
-// Ignore releases stuck in a transient state for over an hour (e.g. orphaned
-// legacy builds) so a wedged release doesn't show a permanent spinner.
 const IN_FLIGHT_MAX_AGE_MS = 60 * 60 * 1000;
 
 export type CanvasReleasePhase = 'queued' | 'building' | 'deploying' | 'rollout';

--- a/services/dashboard/src/pages/EnvironmentPage.vue
+++ b/services/dashboard/src/pages/EnvironmentPage.vue
@@ -228,8 +228,6 @@ const RELEASE_TRANSIENT_STATUSES = new Set<ReleaseStatus>([
   ReleaseStatus.Building,
   ReleaseStatus.Deploying,
 ]);
-// Stop live-polling for releases stuck in a transient state (e.g. orphaned
-// legacy builds) — they'd otherwise keep the environment query polling forever.
 const RELEASE_POLL_MAX_AGE_MS = 60 * 60 * 1000;
 
 function isReleaseInFlight(release: { status: ReleaseStatus; createdAt: string }): boolean {


### PR DESCRIPTION
This PR implements an admission queue for build and deploy jobs. It regulates the maximum of currently active pipeline runs per workspace and globally. It does that by creating all jobs as suspended by default, essentially queuing them. Then the admission reconcile loop (running every 3s) checks all currently queued pipeline runs and starts the oldest one if it fits the configured thresholds for maximum concurrency (workspace-wide and globally). Additionally the deploy handler checks if the queue is full and rejects new pipeline runs if it is.

The motivation behind this change is to prevent abuse, DoS, and limit noisy neighbor problems.