### PR TITLE
scope builds by service

### DIFF
--- a/services/conductor/cmd/conductor/rundeploy.go
+++ b/services/conductor/cmd/conductor/rundeploy.go
@@ -93,8 +93,7 @@ func runDeploy() {
 		return
 	}
 
-	imageRepository := serviceID.Workspace + "/" + serviceID.Project + "/" + serviceID.Name
-	ref, err := build.BuiltImage(imageRepository)
+	ref, err := build.BuiltImage(serviceID.ImageRepository())
 
 	if err != nil {
 		log.Error("deploy: build succeeded but image unusable", "error", err)

--- a/services/conductor/internal/api/graphql/service.resolvers.go
+++ b/services/conductor/internal/api/graphql/service.resolvers.go
@@ -240,7 +240,7 @@ func (r *serviceResolver) Deployments(ctx context.Context, obj *model.Service) (
 
 // Builds is the resolver for the builds field.
 func (r *serviceResolver) Builds(ctx context.Context, obj *model.Service) ([]model.Build, error) {
-	builds, err := r.Conductor.Builds(ctx, obj.ID.Workspace, obj.SourceURL, obj.ContextPath)
+	builds, err := r.Conductor.Builds(ctx, obj.ID)
 
 	if err != nil {
 		return nil, err

--- a/services/conductor/internal/buildjob/interface.go
+++ b/services/conductor/internal/buildjob/interface.go
@@ -11,18 +11,19 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 
 	"github.com/zeitlos/lucity/services/conductor/internal/image"
+	"github.com/zeitlos/lucity/services/conductor/internal/platform"
 )
 
 type Interface interface {
 	Get(ctx context.Context, id BuildID) (*Job, error)
-	List(ctx context.Context, workspaceID, repoURL, contextPath string) ([]Job, error)
+	List(ctx context.Context, service platform.ServiceID) ([]Job, error)
 	Start(ctx context.Context, opts StartOptions) (*Job, error)
 	Cancel(ctx context.Context, id BuildID) (*Job, error)
 	Logs(ctx context.Context, id BuildID) (io.ReadCloser, error)
 }
 
 type StartOptions struct {
-	Workspace        string
+	Service          platform.ServiceID
 	RepoURL          string
 	Commit           string
 	CommitMessage    string

--- a/services/conductor/internal/buildjob/kubernetes/get.go
+++ b/services/conductor/internal/buildjob/kubernetes/get.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/zeitlos/lucity/pkg/labels"
 	"github.com/zeitlos/lucity/services/conductor/internal/buildjob"
 	"github.com/zeitlos/lucity/services/conductor/internal/jobs"
 
@@ -25,7 +26,7 @@ func (c *Client) Get(ctx context.Context, id buildjob.BuildID) (*buildjob.Job, e
 		return nil, err
 	}
 
-	if job.Labels[labelWorkspace] != id.Workspace {
+	if job.Labels[labels.Workspace] != id.Workspace {
 		return nil, fmt.Errorf("build %q not found", id.Name)
 	}
 

--- a/services/conductor/internal/buildjob/kubernetes/kubernetes.go
+++ b/services/conductor/internal/buildjob/kubernetes/kubernetes.go
@@ -1,15 +1,13 @@
 package kubernetes
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"log/slog"
-	"net/url"
-	"path"
 	"strings"
 
 	"github.com/zeitlos/lucity/pkg/github"
+	"github.com/zeitlos/lucity/pkg/labels"
 	"github.com/zeitlos/lucity/services/conductor/internal/buildjob"
+	"github.com/zeitlos/lucity/services/conductor/internal/platform"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	batch "k8s.io/api/batch/v1"
@@ -18,11 +16,9 @@ import (
 )
 
 const (
-	labelWorkspace    = "lucity.dev/workspace"
-	labelRepoHash     = "lucity.dev/source-repo-hash"
-	labelSourceCommit = "lucity.dev/source-commit"
-	labelContextHash  = "lucity.dev/source-context-hash"
-	labelRelease      = "lucity.dev/release"
+	labelComponent    = labels.Prefix + "component"
+	componentBuild    = "build"
+	labelSourceCommit = labels.Prefix + "source-commit"
 )
 
 const (
@@ -64,14 +60,14 @@ var _ buildjob.Interface = (*Client)(nil)
 
 func toJob(job batch.Job) buildjob.Job {
 	build := buildjob.Job{
-		ID:            buildjob.BuildID{Workspace: job.Labels[labelWorkspace], Name: job.Name},
+		ID:            buildjob.BuildID{Workspace: job.Labels[labels.Workspace], Name: job.Name},
 		Status:        buildStatus(job),
 		SourceURL:     job.Annotations[annotationSourceRepo],
 		Commit:        job.Labels[labelSourceCommit],
 		CommitMessage: job.Annotations[annotationCommitMessage],
 		ContextPath:   job.Annotations[annotationContext],
 		TriggeredBy:   job.Annotations[annotationTriggeredBy],
-		ReleaseID:     job.Labels[labelRelease],
+		ReleaseID:     job.Labels[labels.Release],
 		CreatedAt:     job.CreationTimestamp.Time,
 		ImageRefs:     make(map[string]name.Reference),
 	}
@@ -132,29 +128,12 @@ func buildStatus(job batch.Job) buildjob.Status {
 	return buildjob.StatusQueued
 }
 
-func normalizeRepoURL(u url.URL) string {
-	normalized := u.Host + strings.TrimSuffix(u.Path, ".git")
-	normalized = strings.ToLower(normalized)
-
-	return strings.TrimSuffix(normalized, "/")
-}
-
-func normalizeContextPath(contextPath string) string {
-	normalized := path.Clean(strings.TrimSpace(contextPath))
-
-	if normalized == "." || normalized == "/" {
-		return ""
+func buildJobLabels(service platform.ServiceID) map[string]string {
+	return map[string]string{
+		labels.Workspace:   service.Workspace,
+		labels.Project:     service.Project,
+		labels.Environment: service.Environment,
+		labels.Service:     service.Name,
+		labelComponent:     componentBuild,
 	}
-
-	return strings.TrimPrefix(normalized, "/")
-}
-
-func repoURLHash(u url.URL) string {
-	hash := sha256.Sum256([]byte(normalizeRepoURL(u)))
-	return hex.EncodeToString(hash[:8])
-}
-
-func contextHash(contextPath string) string {
-	hash := sha256.Sum256([]byte(normalizeContextPath(contextPath)))
-	return hex.EncodeToString(hash[:8])
 }

--- a/services/conductor/internal/buildjob/kubernetes/lifecycle.go
+++ b/services/conductor/internal/buildjob/kubernetes/lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/joho/godotenv"
+	"github.com/zeitlos/lucity/pkg/labels"
 	"github.com/zeitlos/lucity/services/conductor/internal/buildjob"
 
 	batch "k8s.io/api/batch/v1"
@@ -18,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
 )
@@ -44,8 +45,11 @@ func (c *Client) Start(ctx context.Context, opts buildjob.StartOptions) (*buildj
 		tag = tag[:7]
 	}
 
+	dedupe := buildJobLabels(opts.Service)
+	dedupe[labelSourceCommit] = opts.Commit
+
 	existing, err := c.kubernetes.BatchV1().Jobs(c.namespace).List(ctx, meta.ListOptions{
-		LabelSelector: labels.Set(buildJobLabels(opts.Workspace, *parsed, opts.ContextPath, opts.Commit)).String(),
+		LabelSelector: k8slabels.Set(dedupe).String(),
 	})
 
 	if err != nil {
@@ -105,7 +109,7 @@ func (c *Client) Cancel(ctx context.Context, id buildjob.BuildID) (*buildjob.Job
 		return nil, err
 	}
 
-	if job.Labels[labelWorkspace] != id.Workspace {
+	if job.Labels[labels.Workspace] != id.Workspace {
 		return nil, errors.New("build not found")
 	}
 
@@ -193,10 +197,11 @@ func (c *Client) newBuildJob(id string, opts buildjob.StartOptions, repoURL url.
 		})
 	}
 
-	labels := buildJobLabels(opts.Workspace, repoURL, opts.ContextPath, opts.Commit)
+	labelSet := buildJobLabels(opts.Service)
+	labelSet[labelSourceCommit] = opts.Commit
 
 	if opts.ReleaseID != "" {
-		labels[labelRelease] = opts.ReleaseID
+		labelSet[labels.Release] = opts.ReleaseID
 	}
 
 	annotations := map[string]string{
@@ -213,7 +218,7 @@ func (c *Client) newBuildJob(id string, opts buildjob.StartOptions, repoURL url.
 		ObjectMeta: meta.ObjectMeta{
 			Name:        id,
 			Namespace:   c.namespace,
-			Labels:      labels,
+			Labels:      labelSet,
 			Annotations: annotations,
 		},
 		Spec: batch.JobSpec{
@@ -222,7 +227,7 @@ func (c *Client) newBuildJob(id string, opts buildjob.StartOptions, repoURL url.
 			TTLSecondsAfterFinished: ptr.To(int32(7 * 24 * 3600)),
 			ActiveDeadlineSeconds:   ptr.To(int64(30 * 60)),
 			Template: core.PodTemplateSpec{
-				ObjectMeta: meta.ObjectMeta{Labels: labels},
+				ObjectMeta: meta.ObjectMeta{Labels: labelSet},
 				Spec: core.PodSpec{
 					HostUsers:                    ptr.To(false),
 					RestartPolicy:                core.RestartPolicyNever,
@@ -270,14 +275,4 @@ func truncate(s string, max int) string {
 	}
 
 	return cut
-}
-
-func buildJobLabels(workspaceID string, repoURL url.URL, contextPath, commit string) map[string]string {
-	return map[string]string{
-		labelWorkspace:         workspaceID,
-		labelRepoHash:          repoURLHash(repoURL),
-		labelContextHash:       contextHash(contextPath),
-		labelSourceCommit:      commit,
-		"lucity.dev/component": "build",
-	}
 }

--- a/services/conductor/internal/buildjob/kubernetes/list.go
+++ b/services/conductor/internal/buildjob/kubernetes/list.go
@@ -2,27 +2,16 @@ package kubernetes
 
 import (
 	"context"
-	"net/url"
 	"sort"
 
 	"github.com/zeitlos/lucity/services/conductor/internal/buildjob"
+	"github.com/zeitlos/lucity/services/conductor/internal/platform"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 )
 
-func (c *Client) List(ctx context.Context, workspaceID, repoURL, contextPath string) ([]buildjob.Job, error) {
-	parsedURL, err := url.Parse(repoURL)
-
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Figure out if we can figure by "labelTriggerRef".
-	selector := labels.SelectorFromSet(labels.Set{
-		labelWorkspace:   workspaceID,
-		labelRepoHash:    repoURLHash(*parsedURL),
-		labelContextHash: contextHash(contextPath),
-	})
+func (c *Client) List(ctx context.Context, service platform.ServiceID) ([]buildjob.Job, error) {
+	selector := k8slabels.SelectorFromSet(buildJobLabels(service))
 
 	jobs, err := c.kubernetes.BatchV1().Jobs(c.namespace).List(ctx, meta.ListOptions{
 		LabelSelector: selector.String(),

--- a/services/conductor/internal/buildjob/kubernetes/log.go
+++ b/services/conductor/internal/buildjob/kubernetes/log.go
@@ -7,6 +7,7 @@ import (
 
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/zeitlos/lucity/pkg/labels"
 	"github.com/zeitlos/lucity/services/conductor/internal/buildjob"
 	"github.com/zeitlos/lucity/services/conductor/internal/jobs"
 )
@@ -18,7 +19,7 @@ func (c *Client) Logs(ctx context.Context, id buildjob.BuildID) (io.ReadCloser, 
 		return nil, err
 	}
 
-	if job.Labels[labelWorkspace] != id.Workspace {
+	if job.Labels[labels.Workspace] != id.Workspace {
 		return nil, fmt.Errorf("build %q not found", id.Name)
 	}
 

--- a/services/conductor/internal/conductor/build.go
+++ b/services/conductor/internal/conductor/build.go
@@ -30,8 +30,8 @@ var _ platform.WorkspaceScoped = BuildID{}
 var _ platform.WorkspaceScoped = DeployID{}
 var _ platform.WorkspaceScoped = ScanID{}
 
-func (c *Client) Builds(ctx context.Context, workspace, repoURL, contextPath string) ([]Build, error) {
-	return c.buildjob.List(ctx, workspace, repoURL, contextPath)
+func (c *Client) Builds(ctx context.Context, service platform.ServiceID) ([]Build, error) {
+	return c.buildjob.List(ctx, service)
 }
 
 func (c *Client) Build(ctx context.Context, id BuildID) (*Build, error) {
@@ -138,10 +138,10 @@ func (c *Client) deploy(ctx context.Context, serviceID ServiceID, gitRef string,
 	claims, _ := auth.FromContext(ctx)
 	release := deployer.NewRelease(trigger, actorFromClaims(claims))
 
-	imageName := service.ID.Workspace + "/" + service.ID.Project + "/" + service.Name
+	imageName := service.ID.ImageRepository()
 
 	build, err := c.buildjob.Start(ctx, buildjob.StartOptions{
-		Workspace:        service.ID.Workspace,
+		Service:          service.ID,
 		RepoURL:          service.SourceURL,
 		Commit:           commit.SHA,
 		CommitMessage:    commit.Message,

--- a/services/conductor/internal/conductor/release.go
+++ b/services/conductor/internal/conductor/release.go
@@ -77,18 +77,11 @@ func (c *Client) Releases(ctx context.Context, service platform.Service) ([]Rele
 	var builds []Build
 
 	if service.SourceURL != "" {
-		all, err := c.buildjob.List(ctx, serviceID.Workspace, service.SourceURL, service.ContextPath)
+		var err error
+		builds, err = c.buildjob.List(ctx, serviceID)
 
 		if err != nil {
 			return nil, err
-		}
-
-		target := c.imageRepository(serviceID)
-
-		for _, build := range all {
-			if _, ok := build.ImageRefs[target]; ok {
-				builds = append(builds, build)
-			}
 		}
 	}
 

--- a/services/conductor/internal/conductor/service.go
+++ b/services/conductor/internal/conductor/service.go
@@ -147,7 +147,7 @@ func (c *Client) AddService(ctx context.Context, environmentID platform.Environm
 			return nil, err
 		}
 
-		spec.Image = c.config.RegistryPullURL + "/" + c.imageRepository(id)
+		spec.Image = c.config.RegistryPullURL + "/" + id.ImageRepository()
 	} else if externalImage != "" {
 		if _, err := containername.ParseReference(externalImage); err != nil {
 			return nil, fmt.Errorf("invalid image reference %q: %w", externalImage, err)
@@ -191,10 +191,10 @@ func (c *Client) AddService(ctx context.Context, environmentID platform.Environm
 		claims, _ := auth.FromContext(ctx)
 		release := deployer.NewRelease(deployer.TriggerManual, actorFromClaims(claims))
 
-		imageName := workspace + "/" + projectID + "/" + name
+		imageName := id.ImageRepository()
 
 		build, err := c.buildjob.Start(ctx, buildjob.StartOptions{
-			Workspace:        workspace,
+			Service:          id,
 			RepoURL:          spec.SourceURL,
 			Commit:           commit.SHA,
 			CommitMessage:    commit.Message,
@@ -417,10 +417,6 @@ func (c *Client) ReconcileServices(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func (c *Client) imageRepository(id ServiceID) string {
-	return id.Workspace + "/" + id.Project + "/" + id.Name
 }
 
 // deriveServiceName extracts a service name from an image reference.

--- a/services/conductor/internal/platform/service.go
+++ b/services/conductor/internal/platform/service.go
@@ -116,6 +116,10 @@ func (s ServiceID) EnvironmentID() EnvironmentID {
 	return EnvironmentID{Workspace: s.Workspace, Project: s.Project, Name: s.Environment}
 }
 
+func (s ServiceID) ImageRepository() string {
+	return s.Workspace + "/" + s.Project + "/" + s.Environment + "/" + s.Name
+}
+
 func (s ServiceID) Namespace() string {
 	return s.EnvironmentID().Namespace()
 }

--- a/services/conductor/internal/scanjob/kubernetes/lifecycle.go
+++ b/services/conductor/internal/scanjob/kubernetes/lifecycle.go
@@ -38,7 +38,7 @@ func (c *Client) Start(ctx context.Context, opts scanjob.StartOptions) (*scanjob
 }
 
 func (c *Client) newScanJob(name string, opts scanjob.StartOptions) *batch.Job {
-	reportRepo := c.config.Registry + "/" + opts.Service.Workspace + "/" + opts.Service.Project + "/" + opts.Service.Name + "/scans"
+	reportRepo := c.config.Registry + "/" + opts.Service.ImageRepository() + "/scans"
 
 	env := []core.EnvVar{
 		{Name: "SCAN_ID", Value: name},

--- a/services/conductor/internal/scanreport/scanreport.go
+++ b/services/conductor/internal/scanreport/scanreport.go
@@ -55,7 +55,7 @@ func New(config Config) *Client {
 // Latest returns the most recent secret-scan report, or nil when the
 // service has never been scanned.
 func (c *Client) Latest(ctx context.Context, service platform.ServiceID) (*Report, error) {
-	repoPath := service.Workspace + "/" + service.Project + "/" + service.Name + "/scans"
+	repoPath := service.ImageRepository() + "/scans"
 
 	repo, err := name.NewRepository(c.config.DialEndpoint+"/"+repoPath, name.Insecure)
 


### PR DESCRIPTION
This PR scopes build jobs strictly by service which prevents releases from leaking across environments. Initially the idea was to de-dup builds on a per-workspace level (same repo, context path, variables and git ref should lead to the same build artifact), but that turned out to not be worth the complexity. 