### PR TITLE
add subPath /data to all volume mounts to ensure empty directory

### DIFF
--- a/charts/lucity-app/templates/deployment.yaml
+++ b/charts/lucity-app/templates/deployment.yaml
@@ -155,6 +155,7 @@ spec:
             {{- range $volName, $path := . }}
             - name: volume-{{ $volName }}
               mountPath: {{ $path | quote }}
+              subPath: data
             {{- end }}
           {{- end }}
       {{- with $svc.volumeMounts }}


### PR DESCRIPTION
This PR ass `subPath: data` to every volume mount. This ensures that the CSI actually creates an empty directory within the volume. Otherwise certain applications (such as mysql) will fail to boot, since the root of the ex4 formatted volume contains the `lost+found` folder.